### PR TITLE
Run Python tests

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -76,4 +76,5 @@ make
 # For more details see here ( https://llvm.org/bugs/show_bug.cgi?id=21083 ).
 # Also, these tests are very intensive, which makes them challenging to run in CI.
 #eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib make check
+eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib make check_python
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
 
 requirements:


### PR DESCRIPTION
Given the C++ tests are a bit involved, they are not run. In the case of Mac, the C++ tests may not be built in some cases due to a compiler bug. Instead of having no real testing, this adds Python testing only during the build. The tests are relatively quick (a few seconds), but are still good at covering the Python interface to VIGRA, which does test some of VIGRA's functionality to make sure things are working correctly.