### PR TITLE
MNT: Pin to JPEG 9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 2
+  number: 3
   detect_binary_files_with_prefix: true
 
 requirements:
@@ -22,7 +22,7 @@ requirements:
     - python
     - nose
     - numpy x.x
-    - jpeg 8d
+    - jpeg 9*
     - libtiff 4.0.*
     - libpng 1.6*
     - fftw
@@ -34,7 +34,7 @@ requirements:
     - libgcc      # [linux]
     - python
     - numpy x.x
-    - jpeg 8d
+    - jpeg 9*
     - libtiff 4.0.*
     - libpng 1.6*
     - fftw


### PR DESCRIPTION
Let's see if we can now pin this to JPEG 9. If it works, maybe the issue was that Homebrew wasn't cleaned out before and it was picking up Homebrew's JPEG. Alternatively, it could be related to any other number of problems that were seen in conda-forge, but are now vanishing ( sort of mysteriously :/ ).

cc @ocefpaf