### PR TITLE
Drop the `gcc` package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,10 @@ env:
 
 
 before_install:
+    # Remove homebrew.
     - brew remove --force $(brew list)
+    - brew cleanup -s
+    - rm -rf $(brew --cache)
 
 install:
     - |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,12 +12,11 @@ source:
 
 build:
   skip: true  # [win]
-  number: 3
+  number: 4
   detect_binary_files_with_prefix: true
 
 requirements:
   build:
-    - gcc         # [linux]
     - cmake
     - python
     - nose
@@ -31,7 +30,6 @@ requirements:
     - zlib 1.2*
     
   run:
-    - libgcc      # [linux]
     - python
     - numpy x.x
     - jpeg 9*


### PR DESCRIPTION
Fixes https://github.com/conda-forge/vigra-feedstock/issues/6

Drops the `gcc` package and uses the compiler in the docker image, which is currently devtoolset-2. However, that may change in the future.

Also, re-rendered with `conda-smithy` 0.9.2.