### PR TITLE
Pinning libpng to 1.6.17

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 4
+  number: 5
   detect_binary_files_with_prefix: true
 
 requirements:
@@ -23,7 +23,7 @@ requirements:
     - numpy x.x
     - jpeg 9*
     - libtiff 4.0.*
-    - libpng 1.6*
+    - libpng 1.6.17
     - fftw
     - hdf5 1.8.15*
     - boost
@@ -34,7 +34,7 @@ requirements:
     - numpy x.x
     - jpeg 9*
     - libtiff 4.0.*
-    - libpng 1.6*
+    - libpng 1.6.17
     - fftw
     - hdf5 1.8.15*
     - boost


### PR DESCRIPTION
Appears that I am encountering ABI breaks on Mac with the existing pinning. Not suffering from this on Linux though.

Here we try to fix this by pinning it down to the exact version ( `1.6.17` ) of `libpng` in `defaults`.

While I'm willing to discuss this further and its larger implications throughout the stack, I'm struggling with a broken stack on Mac.

cc @ocefpaf