### PR TITLE
Update HDF5 pinning to 1.8.17

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 5
+  number: 6
   detect_binary_files_with_prefix: true
 
 requirements:
@@ -25,7 +25,7 @@ requirements:
     - libtiff 4.0.*
     - libpng 1.6*
     - fftw
-    - hdf5 1.8.15*
+    - hdf5 1.8.17|1.8.17.*
     - boost 1.60.*
     - zlib 1.2*
     
@@ -36,7 +36,7 @@ requirements:
     - libtiff 4.0.*
     - libpng 1.6*
     - fftw
-    - hdf5 1.8.15*
+    - hdf5 1.8.17|1.8.17.*
     - boost 1.60.*
     - zlib 1.2*
 


### PR DESCRIPTION
As conda-forge is now moving to HDF5 1.8.17 (leapfrogging 1.8.16 for the most part), this bumps VIGRA so that it will also use HDF5 1.8.17.