### PR TITLE
Bump boost to 1.62

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ conda search vigra --channel conda-forge
 ```
 
 
-
 About conda-forge
 =================
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - fftw
     - hdf5 1.8.17|1.8.17.*
     - boost 1.61.*
-    - zlib 1.2*
+    - zlib 1.2.*
     
   run:
     - python
@@ -38,7 +38,7 @@ requirements:
     - fftw
     - hdf5 1.8.17|1.8.17.*
     - boost 1.61.*
-    - zlib 1.2*
+    - zlib 1.2.*
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - libpng 1.6*
     - fftw
     - hdf5 1.8.17|1.8.17.*
-    - boost 1.61.*
+    - boost 1.62.*
     - zlib 1.2.*
     
   run:
@@ -37,7 +37,7 @@ requirements:
     - libpng 1.6*
     - fftw
     - hdf5 1.8.17|1.8.17.*
-    - boost 1.61.*
+    - boost 1.62.*
     - zlib 1.2.*
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 7
+  number: 8
   detect_binary_files_with_prefix: true
 
 requirements:


### PR DESCRIPTION
* Re-renders the feedstock with `conda-smithy` version `1.5.1`.
* Fixes the `zlib` pinning.
* Bumps the `boost` pinning to `1.62`.
* Bumps the build number to `8`.