### PR TITLE
Update pinnings

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ requirements:
     - libtiff >=4.0.3,<4.0.8
     - libpng >=1.6.22,<1.6.31
     - fftw
-    - hdf5 1.8.18|1.8.18.*
+    - hdf5 1.10.1
     - boost 1.65.1
     - zlib 1.2.11
     
@@ -55,7 +55,7 @@ requirements:
     - libtiff >=4.0.3,<4.0.8
     - libpng >=1.6.22,<1.6.31
     - fftw
-    - hdf5 1.8.18|1.8.18.*
+    - hdf5 1.10.1
     - boost 1.65.1
     - zlib 1.2.11
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ requirements:
     - fftw
     - hdf5 1.8.18|1.8.18.*
     - boost 1.64.*
-    - zlib 1.2.*
+    - zlib 1.2.11
     
   run:
     - python
@@ -57,7 +57,7 @@ requirements:
     - fftw
     - hdf5 1.8.18|1.8.18.*
     - boost 1.64.*
-    - zlib 1.2.*
+    - zlib 1.2.11
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - libpng >=1.6.22,<1.6.31
     - fftw
     - hdf5 1.8.18|1.8.18.*
-    - boost 1.64.*
+    - boost 1.65.1
     - zlib 1.2.11
     
   run:
@@ -56,7 +56,7 @@ requirements:
     - libpng >=1.6.22,<1.6.31
     - fftw
     - hdf5 1.8.18|1.8.18.*
-    - boost 1.64.*
+    - boost 1.65.1
     - zlib 1.2.11
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
 
 build:
   skip: true  # [win and py<35]
-  number: 3
+  number: 4
   detect_binary_files_with_prefix: true
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - numpy 1.11.*  # [win and py36]
     - jpeg 9*
     - libtiff >=4.0.3,<4.0.8
-    - libpng 1.6*
+    - libpng >=1.6.22,<1.6.31
     - fftw
     - hdf5 1.8.18|1.8.18.*
     - boost 1.64.*
@@ -53,7 +53,7 @@ requirements:
     - numpy >=1.11  # [win and py36]
     - jpeg 9*
     - libtiff >=4.0.3,<4.0.8
-    - libpng 1.6*
+    - libpng >=1.6.22,<1.6.31
     - fftw
     - hdf5 1.8.18|1.8.18.*
     - boost 1.64.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - numpy 1.9.*  # [win and py35]
     - numpy 1.11.*  # [win and py36]
     - jpeg 9*
-    - libtiff 4.0.*
+    - libtiff >=4.0.3,<4.0.8
     - libpng 1.6*
     - fftw
     - hdf5 1.8.18|1.8.18.*
@@ -52,7 +52,7 @@ requirements:
     - numpy >=1.9  # [win and py35]
     - numpy >=1.11  # [win and py36]
     - jpeg 9*
-    - libtiff 4.0.*
+    - libtiff >=4.0.3,<4.0.8
     - libpng 1.6*
     - fftw
     - hdf5 1.8.18|1.8.18.*


### PR DESCRIPTION
Tightens the `libpng` and `libtiff` pinnings. Tightens the `zlib` pinning. Bumps the `boost` pinning. Also bumps the `hdf5` pinning.

xref: https://github.com/conda-forge/conda-forge.github.io/blob/e346b9b681ca7578c1f64e3ae7b23d35e9ccb5f7/scripts/pin_the_slow_way.py#L40-L95
xref: https://github.com/conda-forge/conda-forge.github.io/pull/482