### PR TITLE
Refresh pinnings

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
 
 build:
   skip: true  # [win and py<35]
-  number: 4
+  number: 5
   detect_binary_files_with_prefix: true
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,8 +39,8 @@ requirements:
     - numpy 1.9.*   # [win and py35]
     - numpy 1.11.*  # [win and py36]
     - jpeg 9*
-    - libtiff >=4.0.3,<4.0.8
-    - libpng >=1.6.22,<1.6.31
+    - libtiff >=4.0.8,<4.0.10
+    - libpng >=1.6.32,<1.6.35
     - fftw
     - hdf5 1.10.1
     - boost 1.65.1
@@ -52,8 +52,8 @@ requirements:
     - numpy >=1.9   # [win and py35]
     - numpy >=1.11  # [win and py36]
     - jpeg 9*
-    - libtiff >=4.0.3,<4.0.8
-    - libpng >=1.6.22,<1.6.31
+    - libtiff >=4.0.8,<4.0.10
+    - libpng >=1.6.32,<1.6.35
     - fftw
     - hdf5 1.10.1
     - boost 1.65.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,8 +35,8 @@ requirements:
     - cmake
     - python
     - nose
-    - numpy 1.8.*  # [not (win and (py35 or py36))]
-    - numpy 1.9.*  # [win and py35]
+    - numpy 1.8.*   # [not (win and (py35 or py36))]
+    - numpy 1.9.*   # [win and py35]
     - numpy 1.11.*  # [win and py36]
     - jpeg 9*
     - libtiff >=4.0.3,<4.0.8
@@ -48,8 +48,8 @@ requirements:
     
   run:
     - python
-    - numpy >=1.8  # [not (win and (py35 or py36))]
-    - numpy >=1.9  # [win and py35]
+    - numpy >=1.8   # [not (win and (py35 or py36))]
+    - numpy >=1.9   # [win and py35]
     - numpy >=1.11  # [win and py36]
     - jpeg 9*
     - libtiff >=4.0.3,<4.0.8


### PR DESCRIPTION
Updates the `libpng` and `libtiff` pinnings to match the global pinnings.

ref: https://github.com/conda-forge/conda-forge.github.io/blob/6bc413f9de7957194afdc239e1f89ba32b549da8/scripts/pin_the_slow_way.py