### PR TITLE
Use boost 1.66.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,24 +43,24 @@ install:
 
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-    - cmd: conda update --yes --quiet conda
+    - cmd: conda.exe update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 
     # Add our channels.
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --remove channels defaults
-    - cmd: conda config --add channels defaults
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda.exe config --set show_channel_urls true
+    - cmd: conda.exe config --remove channels defaults
+    - cmd: conda.exe config --add channels defaults
+    - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
+    - cmd: conda.exe install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - conda build recipe --quiet
+    - conda.exe build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
 
 build:
   skip: true  # [win and py<35]
-  number: 5
+  number: 6
   detect_binary_files_with_prefix: true
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - libpng >=1.6.32,<1.6.35
     - fftw
     - hdf5 1.10.1
-    - boost 1.65.1
+    - boost 1.66.0
     - zlib 1.2.11
     
   run:
@@ -56,7 +56,7 @@ requirements:
     - libpng >=1.6.32,<1.6.35
     - fftw
     - hdf5 1.10.1
-    - boost 1.65.1
+    - boost 1.66.0
     - zlib 1.2.11
 
 test:


### PR DESCRIPTION
Rebuilds `vigra` against `boost` 1.66.0, which is the current pinning in `conda-forge`. Also does a re-render to fix some issues on AppVeyor caused by a new `conda` release.