### PR TITLE
add patch to enable h5py>=3

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,19 +11,19 @@ jobs:
       linux_64_numpy1.18python3.7.____cpython:
         CONFIG: linux_64_numpy1.18python3.7.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_numpy1.18python3.8.____cpython:
         CONFIG: linux_64_numpy1.18python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_numpy1.19python3.7.____73_pypy:
         CONFIG: linux_64_numpy1.19python3.7.____73_pypy
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_numpy1.19python3.9.____cpython:
         CONFIG: linux_64_numpy1.19python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_numpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.18python3.7.____cpython.yaml
@@ -11,7 +11,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 fftw:
 - '3'
 hdf5:
@@ -47,8 +47,6 @@ python:
 target_platform:
 - linux-64
 zip_keys:
-- - cdt_name
-  - docker_image
 - - python
   - numpy
 zlib:

--- a/.ci_support/linux_64_numpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.18python3.8.____cpython.yaml
@@ -11,7 +11,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 fftw:
 - '3'
 hdf5:
@@ -47,8 +47,6 @@ python:
 target_platform:
 - linux-64
 zip_keys:
-- - cdt_name
-  - docker_image
 - - python
   - numpy
 zlib:

--- a/.ci_support/linux_64_numpy1.19python3.7.____73_pypy.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.7.____73_pypy.yaml
@@ -11,7 +11,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 fftw:
 - '3'
 hdf5:
@@ -47,8 +47,6 @@ python:
 target_platform:
 - linux-64
 zip_keys:
-- - cdt_name
-  - docker_image
 - - python
   - numpy
 zlib:

--- a/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
@@ -11,7 +11,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 fftw:
 - '3'
 hdf5:
@@ -47,8 +47,6 @@ python:
 target_platform:
 - linux-64
 zip_keys:
-- - cdt_name
-  - docker_image
 - - python
   - numpy
 zlib:

--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,7 @@ bld.bat text eol=crlf
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
 .scripts/* linguist-generated=true
+.woodpecker.yml linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ conda search vigra --channel conda-forge
 About conda-forge
 =================
 
-[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://numfocus.org)
+[![Powered by
+NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org)
 
 conda-forge is a community-led conda channel of installable packages.
 In order to provide high-quality builds, the process has been automated into the

--- a/build-locally.py
+++ b/build-locally.py
@@ -22,6 +22,10 @@ def setup_environment(ns):
         os.environ["MINIFORGE_HOME"] = os.path.join(
             os.path.dirname(__file__), "miniforge3"
         )
+    if "OSX_SDK_DIR" not in os.environ:
+        os.environ["OSX_SDK_DIR"] = os.path.join(
+            os.path.dirname(__file__), "SDKs"
+        )
 
 
 def run_docker_build(ns):

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,6 +62,9 @@ source:
     # https://github.com/ukoethe/vigra/pull/485
     - pypy_support.diff
 
+    # On master on vigra, but after 1.11.1, no release since
+    - remove-obsolete-h5py.highlevel.patch
+
     #########################################################################
     # Interpreter is statically linked on macOS so do not use `libpython`.  #
     #########################################################################
@@ -76,7 +79,7 @@ source:
     - PR_500.diff
 
 build:
-  number: 1026
+  number: 1027
   detect_binary_files_with_prefix: true
   run_exports:
     # Seems to change ABI between minor versions

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -90,6 +90,7 @@ requirements:
   build:
     - {{ compiler("cxx") }}
     - cmake
+    - make  # [unix]
   host:
     - python
     - nose

--- a/recipe/remove-obsolete-h5py.highlevel.patch
+++ b/recipe/remove-obsolete-h5py.highlevel.patch
@@ -1,0 +1,59 @@
+From 05cb325e3e2430621da7244e19d33bfb1246dd8d Mon Sep 17 00:00:00 2001
+From: Ullrich Koethe <ullrich.koethe@iwr.uni-heidelberg.de>
+Date: Tue, 16 Oct 2018 19:42:39 +0200
+Subject: [PATCH] vigranumpy: removed obsolete h5py.highlevel
+
+---
+ vigranumpy/lib/__init__.py | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/vigranumpy/lib/__init__.py b/vigranumpy/lib/__init__.py
+index e9cff1d6..072a797c 100644
+--- a/vigranumpy/lib/__init__.py
++++ b/vigranumpy/lib/__init__.py
+@@ -200,7 +200,7 @@ def readHDF5(filenameOrGroup, pathInFile, order=None):
+        Requirements: the 'h5py' module must be installed.
+     '''
+     import h5py
+-    if isinstance(filenameOrGroup, h5py.highlevel.Group):
++    if isinstance(filenameOrGroup, h5py.Group):
+         file = None
+         group = filenameOrGroup
+     else:
+@@ -208,7 +208,7 @@ def readHDF5(filenameOrGroup, pathInFile, order=None):
+         group = file['/']
+     try:
+         dataset = group[pathInFile]
+-        if not isinstance(dataset, h5py.highlevel.Dataset):
++        if not isinstance(dataset, h5py.Dataset):
+             raise IOError("readHDF5(): '%s' is not a dataset" % pathInFile)
+         data = dataset.value
+         axistags = dataset.attrs.get('axistags', None)
+@@ -258,7 +258,7 @@ def writeHDF5(data, filenameOrGroup, pathInFile, compression=None, chunks=None):
+        Requirements: the 'h5py' module must be installed.
+     '''
+     import h5py
+-    if isinstance(filenameOrGroup, h5py.highlevel.Group):
++    if isinstance(filenameOrGroup, h5py.Group):
+         file = None
+         group = filenameOrGroup
+     else:
+@@ -272,13 +272,13 @@ def writeHDF5(data, filenameOrGroup, pathInFile, compression=None, chunks=None):
+             g = group.get(groupname, default=None)
+             if g is None:
+                 group = group.create_group(groupname)
+-            elif not isinstance(g, h5py.highlevel.Group):
++            elif not isinstance(g, h5py.Group):
+                 raise IOError("writeHDF5(): invalid path '%s'" % pathInFile)
+             else:
+                 group = g
+         dataset = group.get(levels[-1], default=None)
+         if dataset is not None:
+-            if isinstance(dataset, h5py.highlevel.Dataset):
++            if isinstance(dataset, h5py.Dataset):
+                 del group[levels[-1]]
+             else:
+                 raise IOError("writeHDF5(): cannot replace '%s' because it is not a dataset" % pathInFile)
+-- 
+2.33.0
+


### PR DESCRIPTION
h5py 3.0 deprecated h5py.highlevel, which was used in vigranumpy impex

added patch from vigra master 05cb325e3e2430621da7244e19d33bfb1246dd8d

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
