### PR TITLE
Drop duplicate `conda_forge_output_validation` key

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,7 +4,6 @@ conda_forge_output_validation: true
 provider:
   win: azure
 test_on_native_only: true
-conda_forge_output_validation: true
 github:
   branch_name: main
   tooling_branch_name: main


### PR DESCRIPTION
This key shows up twice in `conda-forge.yml`, which is causing the bot issues. So drop the second occurrence to fix this issue

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes https://github.com/regro/cf-scripts/issues/1523

<!--
Please add any other relevant info below:
-->

xref: https://github.com/conda-forge/vigra-feedstock/pull/89/files#r843321108